### PR TITLE
Fixed new_info columns & added hidden files in pkg

### DIFF
--- a/fetch/linux/exadata/new_info.sh
+++ b/fetch/linux/exadata/new_info.sh
@@ -151,7 +151,7 @@ function HostGetDetails {
             MEMORY_KB=$(dcli -c $NHOST -l root "cat /proc/meminfo|grep MemTotal"|awk '{print $3}')
             MEMORY_GB=$(expr $MEMORY_KB / 1048576)
         fi               
-        echo "$HOST_TYPE|||$RACK_ID|||$HOST|||$CPU_ENABLED|||$CPU_TOT|||$MEMORY_GB|||$IMAGEVERSION|||$KERNEL|||$MODEL|||$FAN_USED|||$FAN_TOTAL|||$PSU_USED|||$PSU_TOTAL|||$MS||$RS"
+        echo "$HOST_TYPE|||$RACK_ID|||$HOST|||$CPU_ENABLED|||$CPU_TOT|||$MEMORY_GB|||$IMAGEVERSION|||$KERNEL|||$MODEL|||$FAN_USED|||$FAN_TOTAL|||$PSU_USED|||$PSU_TOTAL|||$MS|||$RS"
     done < $DBS_LST
 }
 
@@ -195,7 +195,7 @@ function CellGetDetails {
         CELLSRV=$(echo $INFO|awk '{print $8}')
         MS=$(echo $INFO|awk '{print $9}')
         RS=$(echo $INFO_APP|awk '{print $1}')
-        echo "$HOST_TYPE|||$RACK_ID|||$HOST|||$CPU_ENABLED|||$CPU_TOT|||$MEMORY_GB|||$IMAGEVERSION|||$KERNEL|||$MODEL|||$FAN_USED|||$FAN_TOTAL|||$PSU_USED|||$PSU_TOTAL|||$CELLSRV|||$MS||$RS"
+        echo "$HOST_TYPE|||$RACK_ID|||$HOST|||$CPU_ENABLED|||$CPU_TOT|||$MEMORY_GB|||$IMAGEVERSION|||$KERNEL|||$MODEL|||$FAN_USED|||$FAN_TOTAL|||$PSU_USED|||$PSU_TOTAL|||$CELLSRV|||$MS|||$RS"
         echo " "; echo "TYPE|||CELLDISK|||CELL|||SIZE|||FREESPACE|||STATUS|||ERROR_COUNT"
         for CDISK in $CDISKS
         do
@@ -253,7 +253,7 @@ function vmGetDetails {
         IMAGEVERSION=$(echo $INFO|awk '{print $3}')
         MS=$(echo $INFO|awk '{print $4}')
         RS=$(echo $INFO|awk '{print $5}')
-        echo "$HOST_TYPE|||$HOST|||$IMAGEVERSION|||$KERNEL|||$MS||$RS"
+        echo "$HOST_TYPE|||$HOST|||$IMAGEVERSION|||$KERNEL|||$MS|||$RS"
     done < $DBS_LST
 }
 

--- a/package/deb/postinst
+++ b/package/deb/postinst
@@ -32,5 +32,9 @@ echo "/var/log/ercole-agent.log {
     monthly
 }" > /etc/logrotate.d/ercole-agent
 
+'' >> /opt/ercole-agent/.dbs_group
+'' >> /opt/ercole-agent/.cell_group
+'' >> /opt/ercole-agent/.ibs_group
+
 systemctl start ercole-agent.service ;
 systemctl enable ercole-agent.service ;

--- a/package/rhel6/ercole-agent.spec
+++ b/package/rhel6/ercole-agent.spec
@@ -44,6 +44,9 @@ install -m 644 package/rhel6/logrotate $RPM_BUILD_ROOT/etc/logrotate.d/ercole-ag
 
 %post
 chkconfig ercole-agent on
+'' >> /opt/ercole-agent/.dbs_group
+'' >> /opt/ercole-agent/.cell_group
+'' >> /opt/ercole-agent/.ibs_group
 
 %files
 %dir /opt/ercole-agent

--- a/package/rhel7/ercole-agent.spec
+++ b/package/rhel7/ercole-agent.spec
@@ -48,6 +48,9 @@ install -m 0644 package/rhel7/60-ercole-agent.preset %{buildroot}%{_presetdir}/6
 
 %post
 /usr/bin/systemctl preset %{name}.service >/dev/null 2>&1 ||:
+'' >> /opt/ercole-agent/.dbs_group
+'' >> /opt/ercole-agent/.cell_group
+'' >> /opt/ercole-agent/.ibs_group
 
 %preun
 /usr/bin/systemctl --no-reload disable %{name}.service >/dev/null 2>&1 || :

--- a/package/rhel8/ercole-agent.spec
+++ b/package/rhel8/ercole-agent.spec
@@ -48,6 +48,9 @@ install -m 0644 package/rhel7/60-ercole-agent.preset %{buildroot}%{_presetdir}/6
 
 %post
 /usr/bin/systemctl preset %{name}.service >/dev/null 2>&1 ||:
+'' >> /opt/ercole-agent/.dbs_group
+'' >> /opt/ercole-agent/.cell_group
+'' >> /opt/ercole-agent/.ibs_group
 
 %preun
 /usr/bin/systemctl --no-reload disable %{name}.service >/dev/null 2>&1 || :


### PR DESCRIPTION
The new_info fetcher printed some columns value with the wrong format, using `||` but the separator is `|||`.

Some hidden files are going to be created during the installation of ercole-agent to allow the correct use of the new_info fetcher.
